### PR TITLE
Dev: ServerManager for proper Startup and Shutdown control

### DIFF
--- a/Source/ACE.Common/ConfigManager.cs
+++ b/Source/ACE.Common/ConfigManager.cs
@@ -23,6 +23,7 @@ namespace ACE.Common
         public ConfigServerNetwork Network { get; set; }
         public ConfigAccountDefaults Accounts { get; set; }
         public string DatFilesDirectory { get; set; }
+        public ushort ShutdownInterval { get; set; }
     }
 
     public struct ConfigMySqlDatabase

--- a/Source/ACE/ACE.cs
+++ b/Source/ACE/ACE.cs
@@ -16,6 +16,7 @@ namespace ACE
             Console.Title = "ACEmulator";
 
             ConfigManager.Initialise();
+            ServerManager.Initialise();
             DatabaseManager.Initialise();
             AssetManager.Initialise();
             InboundMessageManager.Initialise();

--- a/Source/ACE/ACE.csproj
+++ b/Source/ACE/ACE.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Factories\LootGenerationFactory.cs" />
     <Compile Include="Factories\MonsterFactory.cs" />
     <Compile Include="Factories\PortalObjectFactory.cs" />
+    <Compile Include="Managers\ServerManager.cs" />
     <Compile Include="Managers\AssetManager.cs" />
     <Compile Include="Managers\GuidManager.cs" />
     <Compile Include="Managers\LandblockManager.cs" />

--- a/Source/ACE/Command/Handlers/AdminCommands.cs
+++ b/Source/ACE/Command/Handlers/AdminCommands.cs
@@ -1,5 +1,4 @@
-﻿
-using System;
+﻿using System;
 
 using ACE.Entity;
 using ACE.Entity.Enum;
@@ -1085,6 +1084,111 @@ namespace ACE.Command
             // @stormthresh - Sets how many character can be in a landblock before we do a portal storm.
 
             // TODO: output
+        }
+
+        /// <summary>
+        /// Cancels an in-progress shutdown event.
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="parameters"></param>
+        [CommandHandler("cancel-shutdown", AccessLevel.Admin, CommandHandlerFlag.None, 0)]
+        public static void CancelShutdown(Session session, params string[] parameters)
+        {
+            ServerManager.CancelShutdown();
+        }
+
+        /// <summary>
+        /// Increase or decrease the server shutdown interval in seconds
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="parameters"></param>
+        [CommandHandler("change-shutdown-interval", AccessLevel.Admin, CommandHandlerFlag.None, 1)]
+        public static void ChangeShutdownInterval(Session session, params string[] parameters)
+        {
+            if (parameters?.Length > 0)
+            {
+                uint newShutdownInterval = 0;
+                // delay server shutdown for up to x minutes
+                // limit to uint length 65535
+                string parseInt = parameters[0].Length > 5 ? parameters[0].Substring(0, 5) : parameters[0];
+                if (uint.TryParse(parseInt, out newShutdownInterval))
+                {
+                    if (newShutdownInterval > uint.MaxValue) newShutdownInterval = uint.MaxValue;
+                    // newShutdownInterval is represented as a time element
+                    // parsed from seconds into milliseconds
+                    // example: 2 minutes = 120 seconds = 120000 ms
+                    //          5 minutes = 300 seconds = 300000 ms
+                    //          10 minutes = 600 seconds = 600000 ms
+                    //          30 minutes = 1800 seconds = 1800000 ms
+                    //          1667 minutes = 99999 seconds = 99999000 ms
+                    // (CANNOT)?166667 minutes = 9999999 seconds = 9999999000 ms
+
+                    // set the interval
+                    ServerManager.setShutdownInterval(Convert.ToUInt32(newShutdownInterval));
+
+                    // message the admin
+                    ChatPacket.SendServerMessage(session, $"Shutdown Interval (seconds to shutdown server) has been set to {ServerManager.shutdownInterval}.", ChatMessageType.Broadcast);
+                    return;
+                }
+            }
+            ChatPacket.SendServerMessage(session, "Usage: /change-shutdown-interval <00000000>", ChatMessageType.Broadcast);
+        }
+
+        /// <summary>
+        /// Immediately begins the shutdown process by setting the shutdown interval to 0 before executing the shutdown method
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="parameters"></param>
+        [CommandHandler("stop-now", AccessLevel.Admin, CommandHandlerFlag.None, -1)]
+        public static void ShutdownServerNow(Session session, params string[] parameters)
+        {
+            ServerManager.setShutdownInterval(0);
+            ShutdownServer(session, parameters);
+        }
+
+        /// <summary>
+        /// Function to shutdown the server from console or in-game.
+        /// </summary>
+        /// <param name="session"></param>
+        /// <param name="parameters"></param>
+        [CommandHandler("stop-server", AccessLevel.Admin, CommandHandlerFlag.None, 0)]
+        public static void ShutdownServer(Session session, params string[] parameters)
+        {
+            // inform the world that a shutdown is about to take place
+
+            string shutdownInitiator = (session == null ? "Server" : session.Player.Name.ToString());
+            string shutdownText = "";
+            string adminShutdownText = "";
+
+            // add admin shutdown text
+            if (parameters?.Length > 0)
+            {
+                foreach (var word in parameters)
+                {
+                    if (adminShutdownText.Length > 0)
+                        adminShutdownText += " " + (string)word;
+                    else
+                        adminShutdownText += (string)word;
+                }
+            }
+
+            shutdownText += $"{shutdownInitiator} initiated a complete server shutdown @ {DateTime.UtcNow} UTC";
+
+            // output to console (log in the future)
+            Console.WriteLine(shutdownText);
+            if (adminShutdownText.Length > 0)
+                Console.WriteLine("Admin message: " + adminShutdownText);
+
+            // send a message to each player that the server will go down in x interval
+            foreach (var player in WorldManager.GetAll())
+            {
+                // send server shutdown message
+                player.Network.EnqueueSend(new GameMessageSystemChat(shutdownText, ChatMessageType.Broadcast));
+                if (adminShutdownText.Length > 0)
+                    player.Network.EnqueueSend(new GameMessageSystemChat($"Message from {shutdownInitiator}: {adminShutdownText}", ChatMessageType.Broadcast));
+                player.Network.EnqueueSend(new GameMessageSystemChat($"The server will go down in {ServerManager.shutdownInterval}.", ChatMessageType.Broadcast));
+            }
+            ServerManager.BeginShutdown();
         }
     }
 }

--- a/Source/ACE/Config.json.example
+++ b/Source/ACE/Config.json.example
@@ -9,7 +9,8 @@
             "OverrideCharacterPermissions": true,
             "DefaultAccessLevel": 0
         },
-        "DatFilesDirectory": "c:\\ACE"
+        "DatFilesDirectory": "c:\\ACE",
+        "ShutdownInterval":  "300"
     },
     "MySql": {
         "Authentication": {

--- a/Source/ACE/Managers/ServerManager.cs
+++ b/Source/ACE/Managers/ServerManager.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+using ACE.Database;
+using ACE.Entity;
+using ACE.Common;
+using log4net;
+
+namespace ACE.Managers
+{
+    /// <summary>
+    /// Servermanager handles unloading the server application properly.
+    /// </summary>
+    /// <remarks>
+    ///  Still need to verify that the system unloads properly.
+    ///   Possibly useful for:
+    ///     1. Monitor for errors and performance issues in LandblockManager, GuidManager, WorldManager,
+    ///         DatabaseManager, or AssetManager
+    ///   Known issue:
+    ///     1. No method to verify that everything unloaded properly.
+    /// </remarks>
+    public static class ServerManager
+    {
+        /// <summary>
+        /// Provides a true or false value that indicates advanced warning if the applcation will unload.
+        /// </summary>
+        public static bool shutdownInitiated { get; private set; }
+
+        /// <summary>
+        /// The ammount of seconds that the server will wait before unloading the application.
+        /// </summary>
+        public static uint shutdownInterval { get; private set; }
+
+        public static void setShutdownInterval(uint interval)
+        {
+            log.Warn($"Server shutdown interval reset: {interval}");
+            shutdownInterval = interval;
+        }
+
+        public static void Initialise()
+        {
+            shutdownInterval = ConfigManager.Config.Server.ShutdownInterval;
+        }
+
+        private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);
+
+        /// <summary>
+        /// Starts the shutdown wait thread.
+        /// </summary>
+        public static void BeginShutdown()
+        {
+            shutdownInitiated = true;
+            var shutdownThread = new Thread(ShutdownServer);
+            shutdownThread.Start();
+        }
+
+        /// <summary>
+        /// Calling this function will always cancel an in-progress shutdown (application unload). This will also
+        /// stop the shutdown wait thread and alert users that the server will stay in operation.
+        /// </summary>
+        public static void CancelShutdown()
+        {
+            shutdownInitiated = false;
+        }
+
+        /// <summary>
+        /// Threaded task created when performing a server shutdown
+        /// </summary>
+        private static void ShutdownServer()
+        {
+            DateTime shutdownTime = DateTime.UtcNow.AddSeconds(shutdownInterval);
+
+            // wait for shutdown interval to expire
+            while (shutdownTime != DateTime.MinValue && shutdownTime >= DateTime.UtcNow)
+            {
+                // this allows the server shutdown to be canceled
+                if (!shutdownInitiated)
+                {
+                    // reset shutdown details
+                    string shutdownText = $"The server has canceled the shutdown procedure @ {DateTime.UtcNow} UTC";
+                    log.Warn(shutdownText);
+                    // special text
+                    foreach (var player in WorldManager.GetAll())
+                    {
+                        player.WorldBroadcast(shutdownText);
+                    }
+                    // break function
+                    return;
+                }
+            }
+
+            // logout each player
+            foreach (var player in WorldManager.GetAll())
+            {
+                player.LogOffPlayer();
+            }
+
+            // wait 6 seconds for log-off
+            Thread.Sleep(6000);
+
+            // TODO: Make sure that the landblocks unloads properly.
+
+            // TODO: Make sure that the databasemanager unloads properly.
+
+            // disabled thread update loop and halt application
+            WorldManager.StopWorld();
+            // wait for world to end
+            while (WorldManager.WorldActive)
+            {
+                // no nothing
+            }
+
+            // write exit to console/log
+            log.Warn($"Exiting at {DateTime.UtcNow}");
+            // system exit
+            System.Environment.Exit(System.Environment.ExitCode);
+        }
+    }
+}

--- a/Source/ACE/Managers/WorldManager.cs
+++ b/Source/ACE/Managers/WorldManager.cs
@@ -20,7 +20,8 @@ namespace ACE.Managers
         private static readonly List<Session> sessionStore = new List<Session>();
         private static readonly ReaderWriterLockSlim sessionLock = new ReaderWriterLockSlim();
 
-        private static bool pendingWorldStop;
+        private static volatile bool pendingWorldStop;
+        public static bool WorldActive { get; private set; }
 
         public static DateTime WorldStartTime { get; } = DateTime.UtcNow;
 
@@ -130,6 +131,11 @@ namespace ACE.Managers
             }
         }
 
+        /// <summary>
+        /// Returns a list of all players currently online
+        /// </summary>
+        /// <param name="isOnlineRequired">false returns all players (offline or online)</param>
+        /// <returns>List<> of all online players on the server</returns>
         public static List<Session> GetAll(bool isOnlineRequired = true)
         {
             sessionLock.EnterReadLock();
@@ -146,6 +152,10 @@ namespace ACE.Managers
             }
         }
 
+        /// <summary>
+        /// Removes a player or worldobject from the active world.
+        /// </summary>
+        /// <param name="session"></param>
         public static void Remove(Session session)
         {
             sessionLock.EnterWriteLock();
@@ -159,12 +169,18 @@ namespace ACE.Managers
             }
         }
 
+        /// <summary>
+        /// Function to begin ending the operations inside of an active world.
+        /// </summary>
         public static void StopWorld() { pendingWorldStop = true; }
 
+        /// <summary>
+        /// Main Threaded Applcation loop that advances a world forward in time.
+        /// </summary>
         private static void UpdateWorld()
         {
             double lastTick = 0d;
-
+            WorldActive = true;
             var worldTickTimer = new Stopwatch();
             while (!pendingWorldStop)
             {
@@ -185,6 +201,8 @@ namespace ACE.Managers
                 lastTick = (double)worldTickTimer.ElapsedTicks / Stopwatch.Frequency;
                 PortalYearTicks += lastTick;
             }
+            // world has finished operations and concedes the thread to garbage collection
+            WorldActive = false;
         }
     }
 }

--- a/Source/ACE/Network/Session.cs
+++ b/Source/ACE/Network/Session.cs
@@ -223,5 +223,15 @@ namespace ACE.Network
 
             Player = null;
         }
+
+        /// <summary>
+        /// Sends a broadcast message to the player
+        /// </summary>
+        /// <param name="broadcastMessage"></param>
+        public void WorldBroadcast(string broadcastMessage)
+        {
+            var worldBroadcastMessage = new GameMessageSystemChat(broadcastMessage, ChatMessageType.Broadcast);
+            Network.EnqueueSend(worldBroadcastMessage);
+        }
     }
 }


### PR DESCRIPTION
This pull request provides a `ServerManager` object that will handle unloading the application, in the "safest" way we can imagine.

The major reason for this pull request, is too attempt at preventing data loss when turning off the server properly. The best way to describe this idea is to tell you the history of it's inception.

I first started with just a shutdown command for the console that just exited the application, which seemed insufficient when I was saving data to the database. 

Next, I quickly added other control logic that eventually migrated into the WorldManager object. Code in the worldmanager was sufficient, but I felt that I had added to much code to that specific object, especially when other objects would need to be turned off properly as well. Right now I know that the Landblocks will have their own threading, so waiting for that to finish execution will asumped to be mandatory if the data will be persistent.

To accompany the features of shutting down, this PR already includes the following commands:

Stop the server after the interval set in the Config has Passed:
`@stop-server <shutdown text>`
Stop the Server immediately:
`@stop-now`
Cancel an in progress shutdown:
`@cancel-shutdown`
Change the seconds to wait until shutdown:
`@change-shutdown-interval <00000-99999>`

There is also a config change that adds an additional Configuration json variable called `ShutdownInterval` that needs to be set to seconds. The maximum seconds allowed is 99999.

When a shutdown has been initiated, the server will provide feedback too alert the players when the servers will be ending operation, IE: `Server will shutdown in X seconds, initiated by Admin +Ash @ DateTime`. If you include text after the @stop-server command, then the server message will also include  the text as a shutdown message "Message from +Ash: Shutting down for Sunday maintenance.".

Feel free to propose a better name then `ServerManager`, I understand it's a big hammer.

As a conceptual outlook, I see that this feature-set may later be expanded on too also provide monitoring for other Managers:
1. `ServerManager` could be used as a controller object to watch that `WorldManager` has unloaded the players properly, and that the `DatabaseManager` saves the Landblock Changes to the database at the correct time, after the `LandblockManger` has finishing save process.
2. Start each Manager Object, instead of the main loop in `ACE.cs`.
3. Restart a world or Pause a server.
4. Provide a mechanism that will ensure the Managers have all properly stopped.
5. Change the log4net mechanisms and output.
6. House the log4net logging object: 

`private static readonly ILog log = LogManager.GetLogger(System.Reflection.MethodBase.GetCurrentMethod().DeclaringType);` is currently in everything that needs to be logged. Without testing performance issues, would a publicly accessible log method in the `ServerManager` object cut down on code and confusion?

7. Manage the Console Window output, title, and reporting.
6. Monitor latency to the Database server.
7. Monitor the ability for the database object to reach the database server, on disconnect it could pause the world until the connection has restored or switch to a backup db server.

If any of these concepts are appealing, please create individual issues/requests for them, and I will work on them further.

I know I am getting ahead of myself by 8 miles, but my development plan to support `live testing`: 
Windows Build-> ssh contents to server-> ssh open screen send "@stop-server new development build released, restarting with new build in 5 minutes"-> users get alert of server shutdown-> logs off safely when the server shuts down safely -> a script that is watching if the server crashes will do database migrations for backup-> restart with the latest build -> users can start testing latest changes

Here is the log:

- Added server shutdown command for admins - will be needed in consoles.

- Added shutdown text, logoff, admin shutdown message

- Added ShutdownInterval to the ConfigManager Server Section

- Added ChangeShutdownInterval command, Fixed seconds on shutdown

- Added @stop-server, @stop-now, @cancel-shutdown

- Moved Shutdown to a thread in worldmanager 

- Fixed code style and upstream merge

- Added ShutdownInterval to the example config

- Added more comments and moved the shutdownInterval to a private accessor to tell the console when it changes

- Added log4net and moved exit to ServerManager